### PR TITLE
fix POD example of strict mode import

### DIFF
--- a/lib/File/ShareDir/ProjectDistDir.pm
+++ b/lib/File/ShareDir/ProjectDistDir.pm
@@ -512,7 +512,7 @@ you install that, you specify the different directory there also ) as follows:
 =head4 Using Strict Mode
 
     use File::ShareDir::ProjectDistDir ':all', strict => 1;
-    use File::ShareDir::ProjectDistDir 'dist_dir' => { defaults => { strict => 1 }};
+    use File::ShareDir::ProjectDistDir 'dist_dir' => { strict => 1 };
 
 =head4 Why you should use strict mode
 


### PR DESCRIPTION
Hi,

One of the strict mode examples doesn't work. I'm not especially familiar with Sub::Exporter but I think you meant the following:

    use File::ShareDir::ProjectDistDir 'dist_dir' => { strict => 1 };

Which does seem to set strict mode.

thanks,
Michael   